### PR TITLE
Add support for film stock in metadata

### DIFF
--- a/src/lib/utils/metadata.spec.ts
+++ b/src/lib/utils/metadata.spec.ts
@@ -170,6 +170,145 @@ describe('formatMetadata', () => {
 		});
 	});
 
+	describe('film stock detection', () => {
+		it('detects Kodak Gold with format', () => {
+			const result = formatMetadata({ ImageDescription: 'Kodak Gold 200 (FF)' });
+			expect(result).toHaveLength(2);
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Gold 200' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '35mm' });
+		});
+
+		it('detects Kodak Ektar with format', () => {
+			const result = formatMetadata({ ImageDescription: 'Kodak Ektar 100 (FF)' });
+			expect(result).toHaveLength(2);
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Ektar 100' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '35mm' });
+		});
+
+		it('detects Kodak Portra with medium format', () => {
+			const result = formatMetadata({
+				ImageDescription: 'Kodak Portra 400 (6x6)'
+			});
+			expect(result).toHaveLength(2);
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Portra 400' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '6x6' });
+		});
+
+		it('detects Kodak Gold with 6x9 format', () => {
+			const result = formatMetadata({
+				ImageDescription: 'Kodak Gold 200 (6x9)'
+			});
+			expect(result).toHaveLength(2);
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Gold 200' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '6x9' });
+		});
+
+		it('detects Ilford Delta and strips format', () => {
+			const result = formatMetadata({
+				ImageDescription: 'Ilford Delta 3200 (FF)'
+			});
+			expect(result[0]!).toEqual({
+				label: 'Film Stock',
+				value: 'Ilford Delta 3200'
+			});
+			expect(result[1]!).toEqual({ label: 'Format', value: '35mm' });
+		});
+
+		it('detects Ilford HP5 with push notation and no format', () => {
+			const result = formatMetadata({ ImageDescription: 'Ilford HP5 +2' });
+			expect(result).toHaveLength(1);
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Ilford HP5 +2' });
+		});
+
+		it('detects Fujifilm Provia from Fujichrome description', () => {
+			const result = formatMetadata({
+				ImageDescription: 'Fujifilm Fujichrome Provia 100F (6x9)'
+			});
+			expect(result[0]!).toEqual({
+				label: 'Film Stock',
+				value: 'Fujifilm Provia 100F'
+			});
+			expect(result[1]!).toEqual({ label: 'Format', value: '6x9' });
+		});
+
+		it('detects Fujifilm 200 Color Negative with display override', () => {
+			const result = formatMetadata({
+				ImageDescription: 'Fujifilm FUJIFILM 200 Color Negative (FF)'
+			});
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Fujifilm 200' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '35mm' });
+		});
+
+		it('handles quoted ImageDescription', () => {
+			const result = formatMetadata({
+				ImageDescription: '"Kodak Portra 400 (6x6)"'
+			});
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Portra 400' });
+			expect(result[1]!).toEqual({ label: 'Format', value: '6x6' });
+		});
+
+		it('matches case-insensitively', () => {
+			const result = formatMetadata({ ImageDescription: 'kodak portra 400' });
+			expect(result).toHaveLength(1);
+			expect(result[0]!.label).toBe('Film Stock');
+		});
+
+		it('detects T-Max with hyphen', () => {
+			const result = formatMetadata({ ImageDescription: 'Kodak T-Max 400' });
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak T-Max 400' });
+		});
+
+		it('detects TMax without hyphen', () => {
+			const result = formatMetadata({ ImageDescription: 'Kodak TMax 400' });
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak TMax 400' });
+		});
+
+		it('detects Tri-X with hyphen', () => {
+			const result = formatMetadata({ ImageDescription: 'Kodak Tri-X 400' });
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Kodak Tri-X 400' });
+		});
+
+		it('detects Cinestill 800T', () => {
+			const result = formatMetadata({ ImageDescription: 'Cinestill 800T' });
+			expect(result[0]!).toEqual({ label: 'Film Stock', value: 'Cinestill 800T' });
+		});
+
+		it('detects Cinestill 50 D with space', () => {
+			const result = formatMetadata({ ImageDescription: 'Cinestill 50 D' });
+			expect(result[0]!.label).toBe('Film Stock');
+		});
+
+		it('does not match ImageJ software metadata', () => {
+			const result = formatMetadata({ ImageDescription: 'ImageJ=1.54p' });
+			expect(result).toHaveLength(0);
+		});
+
+		it('does not match ImageJ software metadata variant', () => {
+			const result = formatMetadata({ ImageDescription: 'ImageJ=1.54f' });
+			expect(result).toHaveLength(0);
+		});
+
+		it('does not match Negative Lab Pro metadata', () => {
+			const result = formatMetadata({
+				ImageDescription:
+					'Negative Lab Pro v3.0.2 | Color Model: B+W | Pre-Sat: 3 | Tone Profile: Linear + Gamma | WB: None | LUT: Frontier'
+			});
+			expect(result).toHaveLength(0);
+		});
+
+		it('does not match arbitrary description text', () => {
+			const result = formatMetadata({
+				ImageDescription: 'A nice sunset photo'
+			});
+			expect(result).toHaveLength(0);
+		});
+
+		it('does not match bare 800T without Cinestill prefix', () => {
+			const result = formatMetadata({ ImageDescription: '800T something' });
+			expect(result).toHaveLength(0);
+		});
+	});
+
 	describe('complete metadata', () => {
 		it('formats all fields correctly', () => {
 			const result = formatMetadata({
@@ -181,10 +320,11 @@ describe('formatMetadata', () => {
 				Make: 'Canon',
 				Model: 'EOS R5',
 				LensMake: 'Canon',
-				LensModel: 'RF 50mm f/1.2L USM'
+				LensModel: 'RF 50mm f/1.2L USM',
+				ImageDescription: 'Kodak Portra 400 (FF)'
 			});
 
-			expect(result).toHaveLength(7);
+			expect(result).toHaveLength(9);
 			expect(result[0]!).toEqual({ label: 'Time', value: '2024-01-15 14:30:00' });
 			expect(result[1]!).toEqual({ label: 'Shutter Speed', value: '1/250' });
 			expect(result[2]!).toEqual({ label: 'Aperture', value: 'f/2.8' });
@@ -192,6 +332,8 @@ describe('formatMetadata', () => {
 			expect(result[4]!).toEqual({ label: 'Focal Length', value: '50mm' });
 			expect(result[5]!).toEqual({ label: 'Camera', value: 'Canon EOS R5' });
 			expect(result[6]!).toEqual({ label: 'Lens', value: 'Canon RF 50mm f/1.2L USM' });
+			expect(result[7]!).toEqual({ label: 'Film Stock', value: 'Kodak Portra 400' });
+			expect(result[8]!).toEqual({ label: 'Format', value: '35mm' });
 		});
 	});
 });

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -3,6 +3,83 @@ export interface MetadataItem {
 	value: string;
 }
 
+interface FilmStock {
+	brand: string;
+	name: string;
+	pattern: RegExp;
+	displayName?: string;
+}
+
+const FILM_STOCKS: FilmStock[] = [
+	// Kodak
+	{ brand: 'Kodak', name: 'Ektar', pattern: /\bektar\b/i },
+	{ brand: 'Kodak', name: 'Ektachrome', pattern: /\bektachrome\b/i },
+	{ brand: 'Kodak', name: 'Vision', pattern: /\bkodak\s+vision\b/i },
+	{ brand: 'Kodak', name: 'Gold', pattern: /\bkodak\s+gold\b/i },
+	{ brand: 'Kodak', name: 'Ultramax', pattern: /\bultramax\b/i },
+	{ brand: 'Kodak', name: 'Colorplus', pattern: /\bcolorplus\b/i },
+	{ brand: 'Kodak', name: 'Portra', pattern: /\bportra\b/i },
+	{ brand: 'Kodak', name: 'Tri-X', pattern: /\btri-?x\b/i },
+	{ brand: 'Kodak', name: 'T-Max', pattern: /\bt-?max\b/i },
+	// Fujifilm
+	{ brand: 'Fujifilm', name: 'Velvia', pattern: /\bvelvia\b/i },
+	{ brand: 'Fujifilm', name: 'Provia', pattern: /\bprovia\b/i },
+	{ brand: 'Fujifilm', name: 'Fujicolor', pattern: /\bfujicolor\b/i },
+	{
+		brand: 'Fujifilm',
+		name: '200',
+		pattern: /fujifilm\s+\d+\s*color\s*negative/i,
+		displayName: 'Fujifilm 200'
+	},
+	// Cinestill
+	{ brand: 'Cinestill', name: '800T', pattern: /\bcinestill\s+800\s*t\b/i },
+	{ brand: 'Cinestill', name: '500T', pattern: /\bcinestill\s+500\s*t\b/i },
+	{ brand: 'Cinestill', name: '400D', pattern: /\bcinestill\s+400\s*d\b/i },
+	{ brand: 'Cinestill', name: '50D', pattern: /\bcinestill\s+50\s*d\b/i },
+	// Ilford
+	{ brand: 'Ilford', name: 'Delta', pattern: /\bdelta\b/i },
+	{ brand: 'Ilford', name: 'Kentmere', pattern: /\bkentmere\b/i },
+	{ brand: 'Ilford', name: 'HP5', pattern: /\bhp5\b/i },
+	{ brand: 'Ilford', name: 'FP4', pattern: /\bfp4\b/i }
+];
+
+function detectFilmStock(raw: string): { filmStock: string; format: string | null } | null {
+	const cleaned = raw.replace(/"/g, '');
+
+	// Extract format from trailing parenthetical e.g. (FF), (6x6)
+	let format: string | null = null;
+	const formatMatch = cleaned.match(/\(([^)]+)\)\s*$/);
+	if (formatMatch) {
+		format = /^ff$/i.test(formatMatch[1]) ? '35mm' : formatMatch[1];
+	}
+
+	// Remove the parenthetical for matching
+	const withoutFormat = cleaned.replace(/\s*\([^)]+\)\s*$/, '').trim();
+
+	for (const stock of FILM_STOCKS) {
+		if (stock.pattern.test(withoutFormat)) {
+			if (stock.displayName) {
+				return { filmStock: stock.displayName, format };
+			}
+
+			// Construct display: brand + name + suffix (ISO, push/pull, etc.)
+			const namePattern = new RegExp(stock.name.replace(/-/g, '-?'), 'i');
+			const nameMatch = withoutFormat.match(namePattern);
+			if (nameMatch) {
+				const afterName = withoutFormat.slice(nameMatch.index! + nameMatch[0].length);
+				return {
+					filmStock: `${stock.brand} ${nameMatch[0]}${afterName}`,
+					format
+				};
+			}
+
+			return { filmStock: `${stock.brand} ${stock.name}`, format };
+		}
+	}
+
+	return null;
+}
+
 /**
  * Formats EXIF metadata into display-friendly key-value pairs.
  *
@@ -14,6 +91,8 @@ export interface MetadataItem {
  * - Focal Length: Prefers 35mm equivalent, adds 'mm' suffix
  * - Camera: Combines Make and Model, strips quotes
  * - Lens: Combines LensMake and LensModel, strips quotes
+ * - Film Stock: Detected from ImageDescription by matching known film stock names
+ * - Format: Extracted from ImageDescription parenthetical (FF→35mm, 6x6, 6x9, etc.)
  *
  * @param metadata - Raw EXIF metadata as key-value string pairs
  * @returns Array of formatted metadata items for display
@@ -78,6 +157,18 @@ export function formatMetadata(metadata: Record<string, string>): MetadataItem[]
 		items.push({ label: 'Lens', value: `${lensMake} ${lensModel}` });
 	} else if (lensModel) {
 		items.push({ label: 'Lens', value: lensModel });
+	}
+
+	// Film Stock & Format
+	const imageDescription = metadata.ImageDescription;
+	if (imageDescription) {
+		const detected = detectFilmStock(imageDescription);
+		if (detected) {
+			items.push({ label: 'Film Stock', value: detected.filmStock });
+			if (detected.format) {
+				items.push({ label: 'Format', value: detected.format });
+			}
+		}
 	}
 
 	return items;

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -28,7 +28,7 @@ const FILM_STOCKS: FilmStock[] = [
 	{
 		brand: 'Fujifilm',
 		name: '200',
-		pattern: /fujifilm\s+\d+\s*color\s*negative/i,
+		pattern: /fujifilm\s+200\s*color\s*negative/i,
 		displayName: 'Fujifilm 200'
 	},
 	// Cinestill
@@ -49,8 +49,9 @@ function detectFilmStock(raw: string): { filmStock: string; format: string | nul
 	// Extract format from trailing parenthetical e.g. (FF), (6x6)
 	let format: string | null = null;
 	const formatMatch = cleaned.match(/\(([^)]+)\)\s*$/);
-	if (formatMatch) {
-		format = /^ff$/i.test(formatMatch[1]) ? '35mm' : formatMatch[1];
+	if (formatMatch && formatMatch[1]) {
+		const rawFormat = formatMatch[1].trim();
+		format = /^ff$/i.test(rawFormat) ? '35mm' : rawFormat;
 	}
 
 	// Remove the parenthetical for matching
@@ -63,7 +64,8 @@ function detectFilmStock(raw: string): { filmStock: string; format: string | nul
 			}
 
 			// Construct display: brand + name + suffix (ISO, push/pull, etc.)
-			const namePattern = new RegExp(stock.name.replace(/-/g, '-?'), 'i');
+			const escaped = stock.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const namePattern = new RegExp(escaped.replace(/-/g, '-?'), 'i');
 			const nameMatch = withoutFormat.match(namePattern);
 			if (nameMatch) {
 				const afterName = withoutFormat.slice(nameMatch.index! + nameMatch[0].length);


### PR DESCRIPTION
ImageDescription can hide the film stock, so let's expose it carefully.